### PR TITLE
Add description for deploy-jupyter-notebook folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # ml-utilities
+
+## Deploy Jupyter Notebook
+
+The `deploy-jupyter-notebook/` directory contains utilities and scripts to facilitate the deployment of Jupyter Notebooks for data analysis. These scripts help automate setup and deployment tasks ensuring consistent environments and easy sharing of analyses among team members.


### PR DESCRIPTION
This PR adds a description for the deploy-jupyter-notebook folder in the README.md file.